### PR TITLE
Fix after_brushing callback receiving wrong min_x while zooming out

### DIFF
--- a/dist/mg_line_brushing.js
+++ b/dist/mg_line_brushing.js
@@ -209,10 +209,10 @@ function brushing() {
 
             if (brushHistory[args.target].brushed) {
                 brushHistory[args.target].steps.push({
-                    max_x: args.brushed_max_x || args.max_x,
-                    min_x: args.brushed_min_x || args.min_x,
-                    max_y: args.brushed_max_y || args.max_y,
-                    min_y: args.brushed_min_y || args.min_y
+                    max_x: args.brushed_max_x || args.processed.max_x,
+                    min_x: args.brushed_min_x || args.processed.min_x,
+                    max_y: args.brushed_max_y || args.processed.max_y,
+                    min_y: args.brushed_min_y || args.processed.min_y
                 });
             }
 

--- a/src/js/hooks.js
+++ b/src/js/hooks.js
@@ -164,10 +164,10 @@ function brushing() {
 
             if (brushHistory[args.target].brushed) {
                 brushHistory[args.target].steps.push({
-                    max_x: args.brushed_max_x || args.max_x,
-                    min_x: args.brushed_min_x || args.min_x,
-                    max_y: args.brushed_max_y || args.max_y,
-                    min_y: args.brushed_min_y || args.min_y
+                    max_x: args.brushed_max_x || args.processed.max_x,
+                    min_x: args.brushed_min_x || args.processed.min_x,
+                    max_y: args.brushed_max_y || args.processed.max_y,
+                    min_y: args.brushed_min_y || args.processed.min_y
                 });
             }
 


### PR DESCRIPTION
Hello!

This small fix is essentially described in the title. The `step` parameter of the `after_brushing` callback function always contained `min_x = 0` while zooming out and using manual redraw. I was using it to load a more detailed data while zooming in.

This fixes it, even if I am not 100% sure it is the good way of doing it.

Regards!
